### PR TITLE
fix: CloudFront returning raw XML errors

### DIFF
--- a/aws/website_cfn.yml
+++ b/aws/website_cfn.yml
@@ -63,6 +63,14 @@ Resources:
             Condition:
               StringEquals:
                 AWS:SourceArn: !Sub arn:${AWS::Partition}:cloudfront::${AWS::AccountId}:distribution/${WebsiteDistribution}
+          - Effect: Allow
+            Action: s3:ListBucket
+            Resource: !Sub arn:${AWS::Partition}:s3:::${WebsiteBucket}
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub arn:${AWS::Partition}:cloudfront::${AWS::AccountId}:distribution/${WebsiteDistribution}
 
   DistributionOAC:
     Type: AWS::CloudFront::OriginAccessControl

--- a/aws/website_cfn.yml
+++ b/aws/website_cfn.yml
@@ -97,37 +97,37 @@ Resources:
         CustomErrorResponses:
           - ErrorCode: 400
             ResponseCode: 400
-            ResponsePagePath: /errors/400
+            ResponsePagePath: /errors/400/index.html
           - ErrorCode: 403
             ResponseCode: 403
-            ResponsePagePath: /errors/403
+            ResponsePagePath: /errors/403/index.html
           - ErrorCode: 404
             ResponseCode: 404
-            ResponsePagePath: /errors/404
+            ResponsePagePath: /errors/404/index.html
           - ErrorCode: 405
             ResponseCode: 405
-            ResponsePagePath: /errors/405
+            ResponsePagePath: /errors/405/index.html
           - ErrorCode: 414
             ResponseCode: 414
-            ResponsePagePath: /errors/414
+            ResponsePagePath: /errors/414/index.html
           - ErrorCode: 416
             ResponseCode: 416
-            ResponsePagePath: /errors/416
+            ResponsePagePath: /errors/416/index.html
           - ErrorCode: 500
             ResponseCode: 500
-            ResponsePagePath: /errors/500
+            ResponsePagePath: /errors/500/index.html
           - ErrorCode: 501
             ResponseCode: 501
-            ResponsePagePath: /errors/501
+            ResponsePagePath: /errors/501/index.html
           - ErrorCode: 502
             ResponseCode: 502
-            ResponsePagePath: /errors/502
+            ResponsePagePath: /errors/502/index.html
           - ErrorCode: 503
             ResponseCode: 503
-            ResponsePagePath: /errors/503
+            ResponsePagePath: /errors/503/index.html
           - ErrorCode: 504
             ResponseCode: 504
-            ResponsePagePath: /errors/504
+            ResponsePagePath: /errors/504/index.html
         DefaultCacheBehavior:
           AllowedMethods:
             - GET


### PR DESCRIPTION
The `ResponsePagePath` property needs to point at the actual file in S3, not the URL you can view it at (duh).

Also, let the distribution list the website bucket so we get 404 errors when the URL doesn't exist, not 403.