### PR TITLE
fix: Remove AWS infra deploy steps

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -49,12 +49,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_GITHUB_OIDC_ROLE_ARN }}
           aws-region: ap-southeast-2
 
-      - name: Deploy infra
-        env:
-          BUCKET_NAME: ${{ secrets.DOMAIN_NAME }}
-          DISTRIBUTION_ID: ${{ secrets.CERTIFICATE_ARN }}
-        run: task aws:website:deploy
-
       - name: Build website
         run: |
           task --output group \


### PR DESCRIPTION
I can't be bothered fixing the permissions properly right now so just remove the infra deploy step.